### PR TITLE
if文ネストをやめられるようにI/Fを変更した

### DIFF
--- a/src/calcBookSales.ts
+++ b/src/calcBookSales.ts
@@ -1,9 +1,13 @@
 type FanBook = {
   total: number;
+  price: number;
+  events?: EventStock;
+};
+
+type EventStock = {
   sample?: number;
   stock?: number;
   market?: number;
-  price: number;
 };
 
 export const countBookSales = (bookSale: FanBook) =>
@@ -25,16 +29,20 @@ export const calcAllBooksSales = (sales: FanBook[]) => {
 };
 
 const forSaleBooks = (book: FanBook) => {
-  if (book.sample && book.stock && book.market) {
-    return book.sample + book.stock + book.market;
-  } else if (book.sample && book.stock) {
-    return book.sample + book.stock;
-  } else if (book.stock && book.market) {
-    return book.stock + book.market;
-  } else if (book.sample) {
-    return book.sample;
-  } else if (book.market) {
-    return book.market;
+  if (book.events) {
+    if (book.events.sample && book.events.stock && book.events.market) {
+      return book.events.sample + book.events.stock + book.events.market;
+    } else if (book.events.sample && book.events.stock) {
+      return book.events.sample + book.events.stock;
+    } else if (book.events.stock && book.events.market) {
+      return book.events.stock + book.events.market;
+    } else if (book.events.sample) {
+      return book.events.sample;
+    } else if (book.events.market) {
+      return book.events.market;
+    } else {
+      return 0;
+    }
   } else {
     return 0;
   }

--- a/src/calcBookSales.ts
+++ b/src/calcBookSales.ts
@@ -29,21 +29,12 @@ export const calcAllBooksSales = (sales: FanBook[]) => {
 };
 
 const forSaleBooks = (book: FanBook) => {
-  if (book.events) {
-    if (book.events.sample && book.events.stock && book.events.market) {
-      return book.events.sample + book.events.stock + book.events.market;
-    } else if (book.events.sample && book.events.stock) {
-      return book.events.sample + book.events.stock;
-    } else if (book.events.stock && book.events.market) {
-      return book.events.stock + book.events.market;
-    } else if (book.events.sample) {
-      return book.events.sample;
-    } else if (book.events.market) {
-      return book.events.market;
-    } else {
-      return 0;
-    }
-  } else {
-    return 0;
-  }
+  return book.events ? calcStock(book.events) : 0;
+};
+
+const calcStock = (events: EventStock) => {
+  return Object.values(events).reduce(
+    (previous, current) => previous + current,
+    0
+  );
 };

--- a/src/tests/calcBookSales.test.ts
+++ b/src/tests/calcBookSales.test.ts
@@ -7,17 +7,21 @@ import {
 const fanbooks = [
   {
     total: 306,
-    sample: 3,
-    stock: 80,
-    market: 164,
     price: 1000,
+    events: {
+      sample: 3,
+      stock: 80,
+      market: 164,
+    },
   },
   {
     total: 104,
-    sample: 2,
-    stock: 32,
-    market: 35,
     price: 1000,
+    events: {
+      sample: 2,
+      stock: 32,
+      market: 35,
+    },
   },
   {
     total: 20,
@@ -34,9 +38,11 @@ describe("一冊の同人誌の売り上げ数を計算する", () => {
     expect(
       countBookSales({
         total: 306,
-        stock: 80,
-        market: 164,
         price: 1000,
+        events: {
+          stock: 80,
+          market: 164,
+        },
       })
     ).toBe(62);
   });
@@ -45,8 +51,10 @@ describe("一冊の同人誌の売り上げ数を計算する", () => {
     expect(
       countBookSales({
         total: 306,
-        market: 164,
         price: 1000,
+        events: {
+          market: 164,
+        },
       })
     ).toBe(142);
   });
@@ -55,8 +63,10 @@ describe("一冊の同人誌の売り上げ数を計算する", () => {
     expect(
       countBookSales({
         total: 306,
-        sample: 3,
         price: 1000,
+        events: {
+          sample: 3,
+        },
       })
     ).toBe(303);
   });
@@ -74,9 +84,11 @@ describe("一冊の同人誌の売り上げ数を計算する", () => {
     expect(
       countBookSales({
         total: 306,
-        sample: 3,
-        stock: 303,
         price: 1000,
+        events: {
+          sample: 3,
+          stock: 303,
+        },
       })
     ).toBe(0);
   });


### PR DESCRIPTION
## 概要

#15 で次のようなことを書いていた。

> for...ofで繰り返し加算したいな〜とかいうとき、letなしで行ける手段はあるのか？
undefinedの可能性があるもの（a? : stringみたいなやつ。名前わからん）が複数出てきた場合、みんなundefinedケアをどうしてるんだろう？
if式を重ねて処理したがダサ…な感じである。ただケアしないとない場合のパターンが網羅できないので 🤔 である。

よく考えると、if式の中の処理は同じである。
undefinedな可能性があるものをObjectとしてまとめておけば良いのではないかと思った。

1. `Object.value()`でundefinedではないvalueを配列にする
2. `Array.prototype.reduce()`で配列に対して繰り返し足し算する（前の値に加算して配列が終わったら終わる）

こうすると、もし同人誌の計算に関わるパラメータが増減したときにifを修正する必要はない。
全くロジックが同じならこの対応がいいと思った。

よって、Object.value()で処理しやすいようにI/Fを変更し、処理をリファクタリングした。

https://developer.mozilla.org/ja/docs/Web/JavaScript/Reference/Global_Objects/Array/reduce
https://developer.mozilla.org/ja/docs/Web/JavaScript/Reference/Global_Objects/Object/values