### PR TITLE
GitHub Actions でTimezoneを指定してタスク実行してみる

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,5 +20,7 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
         cache: 'npm'
-    - run: npm ci
+    - name: Run CI
+      run: date
+      run: npm ci
     - run: npm test

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,15 +11,15 @@ jobs:
     - uses: actions/checkout@v3
     - name: Check Date
       run: date
-    - name: Set timezone
-      env:
-        TZ: 'Asia/Tokyo'
-      run: date
     - name: Use Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@v3
       with:
         node-version: ${{ matrix.node-version }}
         cache: 'npm'
+      env:
+        TZ: 'Asia/Tokyo'
     - run: date
+      env:
+        TZ: 'Asia/Tokyo'
     - run: npm ci
     - run: npm test

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,6 +7,8 @@ jobs:
     strategy:
       matrix:
         node-version: ["18.x"]
+    env:
+      TZ: 'Asia/Tokyo'
     steps:
     - uses: actions/checkout@v3
     - name: Check Date
@@ -16,10 +18,6 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
         cache: 'npm'
-      env:
-        TZ: 'Asia/Tokyo'
     - run: date
-      env:
-        TZ: 'Asia/Tokyo'
     - run: npm ci
     - run: npm test

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,6 +18,5 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
         cache: 'npm'
-    - run: date
     - run: npm ci
     - run: npm test

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,25 +1,20 @@
-# This workflow will do a clean installation of node dependencies, cache/restore them, build the source code and run tests across different versions of node
-# For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
-
 name: Node.js CI
 
-on:
-  push:
-    branches: [ "main" ]
-  pull_request:
-    branches: [ "main" ]
-
+on: [push]
 jobs:
   build:
-
     runs-on: ubuntu-latest
-
     strategy:
       matrix:
         node-version: ["18.x"]
-
     steps:
     - uses: actions/checkout@v3
+    - name: Check Date
+      run: date
+    - name: Set timezone
+      env:
+        TZ: 'Asia/Tokyo'
+      run: date
     - name: Use Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@v3
       with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,7 +20,6 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
         cache: 'npm'
-    - name: Run CI
-      run: date
-      run: npm ci
+    - run: date
+    - run: npm ci
     - run: npm test


### PR DESCRIPTION
タイムゾーンを指定する際はActionsのenvを用いて設定する。
効いているかわからなかったので、dateコマンドでロケール出力の差分を確認して調べてみた。

試してみたところ 814b77c94b42661a65b8297f05c24e33be42d381 でそのステップに対してのみ`env`の設定が効くことがわかった。
全体に適用するならjobsの下の階層にセットした方が良いのかも？


## 参考URL

- https://zenn.dev/blancpanda/articles/github-actions-cron-timezone-jst
- https://docs.github.com/en/actions/learn-github-actions/variables
- https://zenn.dev/hashito/articles/aef4de448f341b