### PR TITLE
#39 PokeAPIのpokemon APIのレスポンスパラメータから必要な情報を取り出す関数を追加

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,5 +1,4 @@
 #!/usr/bin/env sh
 . "$(dirname -- "$0")/_/husky.sh"
 
-npm test
 npx lint-staged

--- a/custom.d.ts
+++ b/custom.d.ts
@@ -1,0 +1,6 @@
+import { PokeAPI } from "./src/practice-objects/pokeapi";
+
+declare module "*.json" {
+  const json: PokeAPI;
+  export default json;
+}

--- a/src/practice-objects/pokeapi.ts
+++ b/src/practice-objects/pokeapi.ts
@@ -1,0 +1,255 @@
+export type PokeAPI = {
+  abilities: Array<{
+    ability: {
+      name: string;
+      url: string;
+    };
+    is_hidden: boolean;
+    slot: number;
+  }>;
+  base_experience: number;
+  forms: Array<{
+    name: string;
+    url: string;
+  }>;
+  game_indices: Array<{
+    game_index: number;
+    version: {
+      name: string;
+      url: string;
+    };
+  }>;
+  height: number;
+  held_items: Array<{
+    item: {
+      name: string;
+      url: string;
+    };
+    version_details: Array<{
+      rarity: number;
+      version: {
+        name: string;
+        url: string;
+      };
+    }>;
+  }>;
+  id: number;
+  is_default: boolean;
+  location_area_encounters: string;
+  moves: Array<{
+    move: {
+      name: string;
+      url: string;
+    };
+    version_group_details: Array<{
+      level_learned_at: number;
+      move_learn_method: {
+        name: string;
+        url: string;
+      };
+      version_group: {
+        name: string;
+        url: string;
+      };
+    }>;
+  }>;
+  name: string;
+  order: number;
+  past_types: Array<any>;
+  species: {
+    name: string;
+    url: string;
+  };
+  sprites: {
+    back_default: string;
+    back_female: any;
+    back_shiny: string;
+    back_shiny_female: any;
+    front_default: string;
+    front_female: any;
+    front_shiny: string;
+    front_shiny_female: any;
+    other: {
+      dream_world: {
+        front_default: string;
+        front_female: any;
+      };
+      home: {
+        front_default: string;
+        front_female: any;
+        front_shiny: string;
+        front_shiny_female: any;
+      };
+      "official-artwork": {
+        front_default: string;
+        front_shiny: string;
+      };
+    };
+    versions: {
+      "generation-i": {
+        "red-blue": {
+          back_default: string;
+          back_gray: string;
+          back_transparent: string;
+          front_default: string;
+          front_gray: string;
+          front_transparent: string;
+        };
+        yellow: {
+          back_default: string;
+          back_gray: string;
+          back_transparent: string;
+          front_default: string;
+          front_gray: string;
+          front_transparent: string;
+        };
+      };
+      "generation-ii": {
+        crystal: {
+          back_default: string;
+          back_shiny: string;
+          back_shiny_transparent: string;
+          back_transparent: string;
+          front_default: string;
+          front_shiny: string;
+          front_shiny_transparent: string;
+          front_transparent: string;
+        };
+        gold: {
+          back_default: string;
+          back_shiny: string;
+          front_default: string;
+          front_shiny: string;
+          front_transparent: string;
+        };
+        silver: {
+          back_default: string;
+          back_shiny: string;
+          front_default: string;
+          front_shiny: string;
+          front_transparent: string;
+        };
+      };
+      "generation-iii": {
+        emerald: {
+          front_default: string;
+          front_shiny: string;
+        };
+        "firered-leafgreen": {
+          back_default: string;
+          back_shiny: string;
+          front_default: string;
+          front_shiny: string;
+        };
+        "ruby-sapphire": {
+          back_default: string;
+          back_shiny: string;
+          front_default: string;
+          front_shiny: string;
+        };
+      };
+      "generation-iv": {
+        "diamond-pearl": {
+          back_default: string;
+          back_female: any;
+          back_shiny: string;
+          back_shiny_female: any;
+          front_default: string;
+          front_female: any;
+          front_shiny: string;
+          front_shiny_female: any;
+        };
+        "heartgold-soulsilver": {
+          back_default: string;
+          back_female: any;
+          back_shiny: string;
+          back_shiny_female: any;
+          front_default: string;
+          front_female: any;
+          front_shiny: string;
+          front_shiny_female: any;
+        };
+        platinum: {
+          back_default: string;
+          back_female: any;
+          back_shiny: string;
+          back_shiny_female: any;
+          front_default: string;
+          front_female: any;
+          front_shiny: string;
+          front_shiny_female: any;
+        };
+      };
+      "generation-v": {
+        "black-white": {
+          animated: {
+            back_default: string;
+            back_female: any;
+            back_shiny: string;
+            back_shiny_female: any;
+            front_default: string;
+            front_female: any;
+            front_shiny: string;
+            front_shiny_female: any;
+          };
+          back_default: string;
+          back_female: any;
+          back_shiny: string;
+          back_shiny_female: any;
+          front_default: string;
+          front_female: any;
+          front_shiny: string;
+          front_shiny_female: any;
+        };
+      };
+      "generation-vi": {
+        "omegaruby-alphasapphire": {
+          front_default: string;
+          front_female: any;
+          front_shiny: string;
+          front_shiny_female: any;
+        };
+        "x-y": {
+          front_default: string;
+          front_female: any;
+          front_shiny: string;
+          front_shiny_female: any;
+        };
+      };
+      "generation-vii": {
+        icons: {
+          front_default: string;
+          front_female: any;
+        };
+        "ultra-sun-ultra-moon": {
+          front_default: string;
+          front_female: any;
+          front_shiny: string;
+          front_shiny_female: any;
+        };
+      };
+      "generation-viii": {
+        icons: {
+          front_default: string;
+          front_female: any;
+        };
+      };
+    };
+  };
+  stats: Array<{
+    base_stat: number;
+    effort: number;
+    stat: {
+      name: string;
+      url: string;
+    };
+  }>;
+  types: Array<{
+    slot: number;
+    type: {
+      name: string;
+      url: string;
+    };
+  }>;
+  weight: number;
+};

--- a/src/practice-objects/pseudoLegendarys.test.ts
+++ b/src/practice-objects/pseudoLegendarys.test.ts
@@ -1,0 +1,10 @@
+import { createPseudoLegendaryInfo } from "./pseudoLegendarys";
+import dragonite from "../assets/149.json";
+
+it("600族のポケモンの情報をPokeAPIから取り出せる", () => {
+  expect(createPseudoLegendaryInfo(dragonite)).toEqual({
+    id: 149,
+    name: "dragonite",
+    types: ["dragon", "flying"],
+  });
+});

--- a/src/practice-objects/pseudoLegendarys.ts
+++ b/src/practice-objects/pseudoLegendarys.ts
@@ -1,5 +1,15 @@
+import { PokeAPI } from "./pokeapi";
+
 type PseudoLegendary = {
   id: number; // 図鑑番号
   name: string; // ポケモン
   types: string[]; // タイプ
+};
+
+export const createPseudoLegendaryInfo = (param: PokeAPI): PseudoLegendary => {
+  return {
+    id: param.id,
+    name: param.name,
+    types: param.types.map((type) => type.type.name),
+  };
 };

--- a/src/practice-objects/pseudoLegendarys.ts
+++ b/src/practice-objects/pseudoLegendarys.ts
@@ -1,0 +1,5 @@
+type PseudoLegendary = {
+  id: number; // 図鑑番号
+  name: string; // ポケモン
+  types: string[]; // タイプ
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -35,7 +35,7 @@
     // "types": [],                                      /* Specify type package names to be included without being referenced in a source file. */
     // "allowUmdGlobalAccess": true,                     /* Allow accessing UMD globals from modules. */
     // "moduleSuffixes": [],                             /* List of file name suffixes to search when resolving a module. */
-    // "resolveJsonModule": true,                        /* Enable importing .json files. */
+    "resolveJsonModule": true,                        /* Enable importing .json files. */
     // "noResolve": true,                                /* Disallow 'import's, 'require's or '<reference>'s from expanding the number of files TypeScript should add to a project. */
 
     /* JavaScript Support */
@@ -100,5 +100,5 @@
     // "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
     "skipLibCheck": true                                 /* Skip type checking all .d.ts files. */
   },
-  "include": ["./src/**/*.js"]
+  "include": ["./src/**/*",  "src/custom.d.ts"],
 }


### PR DESCRIPTION
## 概要

1. APIレスポンスパラメータのJSONをインポートするためtsconfig.jsonの設定を変更しました
2. custom.d.tsにPokeAPIのインターフェースを設定し型推論できるようにしました
3. APIから #39 のI/Fを持つオブジェクトを返す関数とテストケースを追加しました

600族は全員複合タイプなのでtypesのパターンは1つだけ（2タイプもつのみ）です。
よって、テストケースは1ケースしか書いていません。パラメータが異なるだけでパターンは1種類のみだからです。

## 参考URL

- https://pokeapi.co/docs/v2#pokemon
- https://reacthustle.com/blog/how-to-import-a-json-file-in-typescript （tsconfigの設定）

resolve #39 