### PR TITLE
40 第3世代までのポケモンを詰めた配列を作成

### DIFF
--- a/src/practice-objects/pokeapi.ts
+++ b/src/practice-objects/pokeapi.ts
@@ -2,236 +2,236 @@ export type PokeAPI = {
   abilities: Array<{
     ability: {
       name: string;
-      url: string;
+      url: string | null;
     };
     is_hidden: boolean;
     slot: number;
   }>;
   base_experience: number;
   forms: Array<{
-    name: string;
-    url: string;
+    name: string | null;
+    url: string | null;
   }>;
   game_indices: Array<{
     game_index: number;
     version: {
-      name: string;
-      url: string;
+      name: string | null;
+      url: string | null;
     };
   }>;
   height: number;
   held_items: Array<{
     item: {
-      name: string;
-      url: string;
+      name: string | null;
+      url: string | null;
     };
     version_details: Array<{
       rarity: number;
       version: {
-        name: string;
-        url: string;
+        name: string | null;
+        url: string | null;
       };
     }>;
   }>;
   id: number;
   is_default: boolean;
-  location_area_encounters: string;
+  location_area_encounters: string | null;
   moves: Array<{
     move: {
-      name: string;
-      url: string;
+      name: string | null;
+      url: string | null;
     };
     version_group_details: Array<{
       level_learned_at: number;
       move_learn_method: {
-        name: string;
-        url: string;
+        name: string | null;
+        url: string | null;
       };
       version_group: {
-        name: string;
-        url: string;
+        name: string | null;
+        url: string | null;
       };
     }>;
   }>;
   name: string;
   order: number;
-  past_types: Array<any>;
+  past_types: Array<string | null>;
   species: {
-    name: string;
-    url: string;
+    name: string | null;
+    url: string | null;
   };
   sprites: {
-    back_default: string;
-    back_female: any;
-    back_shiny: string;
-    back_shiny_female: any;
-    front_default: string;
-    front_female: any;
-    front_shiny: string;
-    front_shiny_female: any;
+    back_default: string | null;
+    back_female: string | null;
+    back_shiny: string | null;
+    back_shiny_female: string | null;
+    front_default: string | null;
+    front_female: string | null;
+    front_shiny: string | null;
+    front_shiny_female: string | null;
     other: {
       dream_world: {
-        front_default: string;
-        front_female: any;
+        front_default: string | null;
+        front_female: string | null;
       };
       home: {
-        front_default: string;
-        front_female: any;
-        front_shiny: string;
-        front_shiny_female: any;
+        front_default: string | null;
+        front_female: string | null;
+        front_shiny: string | null;
+        front_shiny_female: string | null;
       };
       "official-artwork": {
-        front_default: string;
-        front_shiny: string;
+        front_default: string | null;
+        front_shiny: string | null;
       };
     };
     versions: {
       "generation-i": {
         "red-blue": {
-          back_default: string;
-          back_gray: string;
-          back_transparent: string;
-          front_default: string;
-          front_gray: string;
-          front_transparent: string;
+          back_default: string | null;
+          back_gray: string | null;
+          back_transparent: string | null;
+          front_default: string | null;
+          front_gray: string | null;
+          front_transparent: string | null;
         };
         yellow: {
-          back_default: string;
-          back_gray: string;
-          back_transparent: string;
-          front_default: string;
-          front_gray: string;
-          front_transparent: string;
+          back_default: string | null;
+          back_gray: string | null;
+          back_transparent: string | null;
+          front_default: string | null;
+          front_gray: string | null;
+          front_transparent: string | null;
         };
       };
       "generation-ii": {
         crystal: {
-          back_default: string;
-          back_shiny: string;
-          back_shiny_transparent: string;
-          back_transparent: string;
-          front_default: string;
-          front_shiny: string;
-          front_shiny_transparent: string;
-          front_transparent: string;
+          back_default: string | null;
+          back_shiny: string | null;
+          back_shiny_transparent: string | null;
+          back_transparent: string | null;
+          front_default: string | null;
+          front_shiny: string | null;
+          front_shiny_transparent: string | null;
+          front_transparent: string | null;
         };
         gold: {
-          back_default: string;
-          back_shiny: string;
-          front_default: string;
-          front_shiny: string;
-          front_transparent: string;
+          back_default: string | null;
+          back_shiny: string | null;
+          front_default: string | null;
+          front_shiny: string | null;
+          front_transparent: string | null;
         };
         silver: {
-          back_default: string;
-          back_shiny: string;
-          front_default: string;
-          front_shiny: string;
-          front_transparent: string;
+          back_default: string | null;
+          back_shiny: string | null;
+          front_default: string | null;
+          front_shiny: string | null;
+          front_transparent: string | null;
         };
       };
       "generation-iii": {
         emerald: {
-          front_default: string;
-          front_shiny: string;
+          front_default: string | null;
+          front_shiny: string | null;
         };
         "firered-leafgreen": {
-          back_default: string;
-          back_shiny: string;
-          front_default: string;
-          front_shiny: string;
+          back_default: string | null;
+          back_shiny: string | null;
+          front_default: string | null;
+          front_shiny: string | null;
         };
         "ruby-sapphire": {
-          back_default: string;
-          back_shiny: string;
-          front_default: string;
-          front_shiny: string;
+          back_default: string | null;
+          back_shiny: string | null;
+          front_default: string | null;
+          front_shiny: string | null;
         };
       };
       "generation-iv": {
         "diamond-pearl": {
-          back_default: string;
-          back_female: any;
-          back_shiny: string;
-          back_shiny_female: any;
-          front_default: string;
-          front_female: any;
-          front_shiny: string;
-          front_shiny_female: any;
+          back_default: string | null;
+          back_female: string | null;
+          back_shiny: string | null;
+          back_shiny_female: string | null;
+          front_default: string | null;
+          front_female: string | null;
+          front_shiny: string | null;
+          front_shiny_female: string | null;
         };
         "heartgold-soulsilver": {
-          back_default: string;
-          back_female: any;
-          back_shiny: string;
-          back_shiny_female: any;
-          front_default: string;
-          front_female: any;
-          front_shiny: string;
-          front_shiny_female: any;
+          back_default: string | null;
+          back_female: string | null;
+          back_shiny: string | null;
+          back_shiny_female: string | null;
+          front_default: string | null;
+          front_female: string | null;
+          front_shiny: string | null;
+          front_shiny_female: string | null;
         };
         platinum: {
-          back_default: string;
-          back_female: any;
-          back_shiny: string;
-          back_shiny_female: any;
-          front_default: string;
-          front_female: any;
-          front_shiny: string;
-          front_shiny_female: any;
+          back_default: string | null;
+          back_female: string | null;
+          back_shiny: string | null;
+          back_shiny_female: string | null;
+          front_default: string | null;
+          front_female: string | null;
+          front_shiny: string | null;
+          front_shiny_female: string | null;
         };
       };
       "generation-v": {
         "black-white": {
           animated: {
-            back_default: string;
-            back_female: any;
-            back_shiny: string;
-            back_shiny_female: any;
-            front_default: string;
-            front_female: any;
-            front_shiny: string;
-            front_shiny_female: any;
+            back_default: string | null;
+            back_female: string | null;
+            back_shiny: string | null;
+            back_shiny_female: string | null;
+            front_default: string | null;
+            front_female: string | null;
+            front_shiny: string | null;
+            front_shiny_female: string | null;
           };
-          back_default: string;
-          back_female: any;
-          back_shiny: string;
-          back_shiny_female: any;
-          front_default: string;
-          front_female: any;
-          front_shiny: string;
-          front_shiny_female: any;
+          back_default: string | null;
+          back_female: string | null;
+          back_shiny: string | null;
+          back_shiny_female: string | null;
+          front_default: string | null;
+          front_female: string | null;
+          front_shiny: string | null;
+          front_shiny_female: string | null;
         };
       };
       "generation-vi": {
         "omegaruby-alphasapphire": {
-          front_default: string;
-          front_female: any;
-          front_shiny: string;
-          front_shiny_female: any;
+          front_default: string | null;
+          front_female: string | null;
+          front_shiny: string | null;
+          front_shiny_female: string | null;
         };
         "x-y": {
-          front_default: string;
-          front_female: any;
-          front_shiny: string;
-          front_shiny_female: any;
+          front_default: string | null;
+          front_female: string | null;
+          front_shiny: string | null;
+          front_shiny_female: string | null;
         };
       };
       "generation-vii": {
         icons: {
-          front_default: string;
-          front_female: any;
+          front_default: string | null;
+          front_female: string | null;
         };
         "ultra-sun-ultra-moon": {
-          front_default: string;
-          front_female: any;
-          front_shiny: string;
-          front_shiny_female: any;
+          front_default: string | null;
+          front_female: string | null;
+          front_shiny: string | null;
+          front_shiny_female: string | null;
         };
       };
       "generation-viii": {
         icons: {
-          front_default: string;
-          front_female: any;
+          front_default: string | null;
+          front_female: string | null;
         };
       };
     };
@@ -240,8 +240,8 @@ export type PokeAPI = {
     base_stat: number;
     effort: number;
     stat: {
-      name: string;
-      url: string;
+      name: string | null;
+      url: string | null;
     };
   }>;
   types: Array<{

--- a/src/practice-objects/pseudoLegendarys.test.ts
+++ b/src/practice-objects/pseudoLegendarys.test.ts
@@ -1,10 +1,19 @@
-import { createPseudoLegendaryInfo } from "./pseudoLegendarys";
+import * as operator from "./pseudoLegendarys";
 import dragonite from "../assets/149.json";
 
 it("600族のポケモンの情報をPokeAPIから取り出せる", () => {
-  expect(createPseudoLegendaryInfo(dragonite)).toEqual({
+  expect(operator.createPseudoLegendaryInfo(dragonite)).toEqual({
     id: 149,
     name: "dragonite",
     types: ["dragon", "flying"],
   });
+});
+
+it("第三世代までの600族のポケモンの配列を返す", () => {
+  expect(operator.through3()).toEqual([
+    { id: 149, name: "dragonite", types: ["dragon", "flying"] },
+    { id: 248, name: "tyranitar", types: ["rock", "dark"] },
+    { id: 373, name: "salamence", types: ["dragon", "flying"] },
+    { id: 376, name: "metagross", types: ["steel", "psychic"] },
+  ]);
 });

--- a/src/practice-objects/pseudoLegendarys.ts
+++ b/src/practice-objects/pseudoLegendarys.ts
@@ -1,4 +1,8 @@
 import { PokeAPI } from "./pokeapi";
+import dragonite from "../assets/149.json";
+import tyranitar from "../assets/248.json";
+import salamence from "../assets/373.json";
+import metagross from "../assets/376.json";
 
 type PseudoLegendary = {
   id: number; // 図鑑番号
@@ -12,4 +16,13 @@ export const createPseudoLegendaryInfo = (param: PokeAPI): PseudoLegendary => {
     name: param.name,
     types: param.types.map((type) => type.type.name),
   };
+};
+
+export const through3 = (): PseudoLegendary[] => {
+  return [
+    createPseudoLegendaryInfo(dragonite),
+    createPseudoLegendaryInfo(tyranitar),
+    createPseudoLegendaryInfo(salamence),
+    createPseudoLegendaryInfo(metagross),
+  ];
 };


### PR DESCRIPTION
1. 第3世代までのポケモンを詰めた配列を作成しました。
2. ポケモンが登場していない世代の情報など、場合によってはnullになるパターンが起きうることが型定義に反映されていないため修正しました。